### PR TITLE
refactor: type hints and doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Entwickelt und getestet für **NVIDIA Quadro T1000 (4 GB VRAM)** + **16 GB RAM**
 
 ## Warum genau dieser Stack?
 
-1. **DexiNed** (Edge-Netz) liefert **feinste und scharfe** Kanten. Wir verwenden den **Annotator** aus `controlnet-aux` und fahren **multi-scale** mit Nachbearbeitung (Hysterese-ähnlich, Closing, Skeletonize). DexiNed ist für sehr feine, zusammenhängende Konturen bekannt. 0  
-2. **Stable Diffusion 1.5 + ControlNet(Lineart)** glättet/normalisiert die aus DexiNed kommenden Linien **ohne** Schattierung oder Farbe – das **Lineart-ControlNet** ist für SD 1.5 trainiert und in der Community Standard. 1  
-3. **SD 1.5** ist im Gegensatz zu **SDXL** auf **4 GB VRAM** verlässlich betreibbar (mit **CPU-Offload**, **Attention/ VAE-Slicing/-Tiling** in Diffusers). SDXL ist auf 4 GB realitätsfern langsam/instabil; daher setzen wir auf SD 1.5. 2  
-4. **VTracer** erzeugt aus der binären Lineart **SVG-Vektoren**, ideal für Unterrichtsmaterial und Druck. 3
+1. **DexiNed** (Edge-Netz) liefert **feinste und scharfe** Kanten. Wir verwenden den **Annotator** aus `controlnet-aux` und fahren **multi-scale** mit Nachbearbeitung (Hysterese-ähnlich, Closing, Skeletonize). DexiNed ist für sehr feine, zusammenhängende Konturen bekannt ([Hugging Face](https://huggingface.co/lllyasviel/Annotators)).
+2. **Stable Diffusion 1.5 + ControlNet(Lineart)** glättet/normalisiert die aus DexiNed kommenden Linien **ohne** Schattierung oder Farbe – das **Lineart-ControlNet** ist für SD 1.5 trainiert und in der Community Standard ([ControlNet Lineart](https://huggingface.co/lllyasviel/control_v11p_sd15_lineart)).
+3. **SD 1.5** ist im Gegensatz zu **SDXL** auf **4 GB VRAM** verlässlich betreibbar (mit **CPU-Offload**, **Attention/ VAE-Slicing/-Tiling** in Diffusers). SDXL ist auf 4 GB realitätsfern langsam/instabil; daher setzen wir auf SD 1.5 ([Stable Diffusion 1.5](https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5)).
+4. **VTracer** erzeugt aus der binären Lineart **SVG-Vektoren**, ideal für Unterrichtsmaterial und Druck ([GitHub](https://github.com/visioncortex/vtracer)).
 
 ---
 


### PR DESCRIPTION
## Summary
- add basic type hints and modern PIL resampling
- guard optional OpenCV features and avoid chained `pack`
- clean README footnotes and link to model resources

## Testing
- `ruff check . --fix`
- `black .`
- `basedpyright` *(fails: DexiNedDetector import missing stubs, many untyped defs)*
- `mypy src` *(fails: missing type stubs, many untyped defs)*
- `pylint src/`
- `vulture src/`
- `deptry .`
- `pydocstyle src/`
- `python - <<'PY' ... PY`


------
https://chatgpt.com/codex/tasks/task_e_68bb2a4d97e483279a07d3f556a94cc1