### PR TITLE
chore: document pipeline and centralise defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@ python main.py
 - SD 1.5 + ControlNet lineart refinement
 - Optional SVG export via VTracer
 
+## Modelle
+- [lllyasviel/Annotators](https://huggingface.co/lllyasviel/Annotators) – DexiNed
+- [lllyasviel/control_v11p_sd15_lineart](https://huggingface.co/lllyasviel/control_v11p_sd15_lineart) – ControlNet
+
 ## Parameter
-- Steps (default 32)
-- Guidance (6.0)
-- Ctrl-Scale (1.0)
-- Strength (0.70)
-- Seed (42)
-- Max lange Kante (896px)
+- Steps (default 32) – ausgewogen zwischen Qualität und Geschwindigkeit
+- Guidance (6.0) – höhere Werte erzwingen stärkere Prompt-Treue
+- Ctrl-Scale (1.0) – Einfluss der ControlNet-Linien
+- Strength (0.70) – Stärke des Img2Img-Effekts
+- Seed (42) – Reproduzierbarkeit
+- Max lange Kante (896px) – begrenzt Rechenaufwand
 
 ## Troubleshooting
 - CUDA nicht gefunden: Installation von passenden Treibern prüfen.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[project]
+name = "lineart"
+version = "0.0.0"
+requires-python = ">=3.8,<3.12"
+
 [tool.black]
 line-length = 88
 target-version = ["py311"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ torch
 diffusers
 transformers
 accelerate
-safetensors
 controlnet-aux
 pillow
 opencv-python


### PR DESCRIPTION
## Summary
- document pipeline functions with Google-style docstrings
- expose default constants and use them in GUI
- document models and defaults in README, tidy requirements and pyproject

## Testing
- `ruff check . --fix`
- `black .`
- `basedpyright`
- `mypy .`
- `pylint src/`
- `vulture src/`
- `deptry .`
- `pydocstyle src/`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbc6e5a4e08327ad1ffb25646160c9