### PR TITLE
Fix image listing

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -171,7 +171,9 @@ def list_images(folder: Path) -> list[Path]:
         None
 
     """
-    return sorted(p for p in folder.glob("*") if p.suffix.lower() in IMG_EXTS)
+    return sorted(
+        p for p in folder.iterdir() if p.is_file() and p.suffix.lower() in IMG_EXTS
+    )
 
 
 def resize_img(w: int, h: int, max_long: int = DEFAULT_MAX_LONG) -> tuple[int, int]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,14 @@ def test_list_images_sorted(tmp_path) -> None:
     assert [f.name for f in files] == ["a.png", "b.png"]
 
 
+def test_list_images_skips_directories(tmp_path) -> None:
+    """list_images ignores directories even if they have an image extension."""
+    (tmp_path / "a.png").mkdir()
+    (tmp_path / "b.png").touch()
+    files = list_images(tmp_path)
+    assert [f.name for f in files] == ["b.png"]
+
+
 def test_detect_dtype_cpu(monkeypatch) -> None:
     """CPU dtype falls back to float32 without CUDA check."""
     import torch


### PR DESCRIPTION
## Summary
- ensure list_images ignores directories masquerading as image files
- add regression test for directory filtering

## Testing
- `ruff check . --fix`
- `black .`
- `basedpyright`
- `mypy src tests main.py --follow-imports=skip`
- `pylint src/`
- `vulture src/`
- `deptry .`
- `pydocstyle src/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bda56c4e308327894f50ef1513d6c0