### PR TITLE
chore(lint): konsolidierter Ruff/BasedPyright/Vulture/Deptry/Refurb-Stack, Doku aktualisiert

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,61 @@
+name: lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Ruff format
+        run: |
+          set -o pipefail
+          . .venv/bin/activate
+          ruff format --check . | tee ruff-format.log
+      - name: Ruff lint
+        run: |
+          set -o pipefail
+          . .venv/bin/activate
+          ruff check . | tee ruff-lint.log
+      - name: BasedPyright
+        run: |
+          set -o pipefail
+          . .venv/bin/activate
+          basedpyright --outputjson | tee pyright-report.json
+      - name: Vulture
+        run: |
+          set -o pipefail
+          . .venv/bin/activate
+          vulture src tests | tee vulture-report.txt
+      - name: Refurb
+        run: |
+          set -o pipefail
+          . .venv/bin/activate
+          refurb src tests | tee refurb-report.txt
+      - name: Deptry
+        run: |
+          set -o pipefail
+          . .venv/bin/activate
+          deptry . | tee deptry-report.txt
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: |
+            ruff-format.log
+            ruff-lint.log
+            pyright-report.json
+            vulture-report.txt
+            refurb-report.txt
+            deptry-report.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.venv/
+.ruff_cache/
+.pyright/
+ruff-format.log
+ruff-lint.log
+pyright-report.json
+vulture-report.txt
+refurb-report.txt
+deptry-report.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.9
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/RobertCraigie/pyright-pre-commit
+    rev: v1.1.358
+    hooks:
+      - id: basedpyright
+        additional_dependencies: ["basedpyright"]
+        stages: [pre-push]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": true,
+    "[python]": {"editor.defaultFormatter": "charliermarsh.ruff"},
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,75 +1,52 @@
-Nach dem nach dem Programmieren, ändern, korrigieren, ergänzen des Codes sollst du eine saubere, reproduzierbare Qualitäts-Pipeline fahren – schnell zuerst, tiefgründig danach:
-Also immer vor dem Abschluss!
-1. Schnelle Auto-Korrektur & Formatierung
+Nach dem Programmieren, Ändern oder Ergänzen des Codes muss eine reproduzierbare Qualitäts-Pipeline laufen – schnell zuerst, gründlich danach. Immer vor dem Abschluss!
 
-Ruff (lint + quick-fix + Imports):
+1. **Formatierung & Linting**
+
+Ruff übernimmt Formatierung, Import-Sortierung und schnelle Fixes:
+```
+ruff format .
 ruff check . --fix
-Fängt Syntax-/Style-Fehler (E/F/W …), sortiert Importe (Regelgruppe I), kann auch Modernisierungen (UP/pyupgrade-Regeln) und Docstring-Checks (D) übernehmen – extrem schnell. 
+```
 
-Black (finale Formatierung):
-black .
-Erzwingt einheitlichen Stil, keine Diskussionen über Formatdetails. (Black liest optional deine pyproject.toml-Settings.) 
+2. **Statische Typprüfung**
 
-Optional isort: nur wenn du nicht willst, dass Ruff die Importe sortiert: isort . (Ruff kann das bereits.) 
+BasedPyright analysiert den Code ohne Node-Abhängigkeit:
+```
+basedpyright --outputjson
+```
 
+3. **Tiefenanalyse der Codequalität**
 
+```
+vulture src tests
+refurb src tests
+```
 
-2. Statische Typprüfung (zwei Perspektiven, mehr Treffer)
+4. **Abhängigkeits-Hygiene**
 
-basedpyright (strenger, sehr schnell): basedpyright
-Vorteil: reines PyPI-Paket, keine Node-Abhängigkeit. 
+```
+deptry .
+```
 
-mypy (zweite Meinung, anderes Regelset): mypy
-Beide Checker finden unterschiedliche Klassen von Typ-Fehlern; Konfiguration bequem in pyproject.toml unter [tool.mypy]. 
-
-
-
-3. Tiefenanalyse der Codequalität
-
-Pylint: pylint src/
-Deckt Naming-Konventionen, Code-Smells, Refactoring-Hinweise ab; findet anderes als Ruff. Pylint kann pyproject.toml lesen. 
-
-Vulture: vulture src/
-Sucht toten/ungenutzten Code (Funktionen, Variablen, Klassen). Konfigurierbar via [tool.vulture] in pyproject.toml. 
-
-
-
-4. Abhängigkeits-Hygiene
-
-Deptry: deptry .
-Findet fehlende, ungenutzte, transitive und falsch genutzte Stdlib-Im-porte; versteht PEP 621-Metadaten aus pyproject.toml ([project], [project.optional-dependencies]). Konfigurierbar via [tool.deptry]. 
-
-
-
-5. Dokumentationsdisziplin
-
-pydocstyle: pydocstyle src/
-Prüft PEP 257-konforme Docstrings. (Alternativ kannst du die D-Regeln über Ruff laufen lassen und pydocstyle weglassen.) 
-
-
-
+Bei jeder Codeänderung muss das vollständige Prüfverfahren mit Ruff, BasedPyright, Vulture, Refurb und Deptry durchgeführt werden.
 
 ---
 
 Minimal sinnvolle Reihenfolge (CLI)
 
-# 1) Schnell fixen & formatieren
+# 1) Format & Lint
+ruff format .
 ruff check . --fix
-black .
 
-# 2) Typchecks
-basedpyright
-mypy
+# 2) Typprüfung
+basedpyright --outputjson
 
 # 3) Tiefenanalyse
-pylint src/
-vulture src/
+vulture src tests
+refurb src tests
 
 # 4) Dependencies prüfen
 deptry .
-
-# 5) (optional, falls nicht via Ruff-D-Regeln)
-pydocstyle src/
 # DexiNed → SD 1.5 + ControlNet Pipeline - Implementierungsstatus
 
 ## 1. ARCHITEKTUR-REFACTORING
@@ -122,7 +99,7 @@ pydocstyle src/
 - [x] Type Hints für Rückgabewerte, auch bei None: `-> None` ✅
 - [x] Google-Style Docstrings mit Args, Returns, Raises Sections für jede Funktion
 - [x] Klassen-Docstrings mit Attributes-Section für alle Instance-Variablen
-- [x] Black-Formatierung: Zeilen max 88 Zeichen, konsistente Quotes ✅
+- [x] Ruff-Formatierung: Zeilen max 88 Zeichen, konsistente Quotes ✅
 - [x] Ruff-Linting: Import-Sortierung, unused imports entfernen ✅
 - [x] Pathlib überall: keine String-Pfade, immer `Path` objects
 - [x] Konstanten in UPPER_CASE am Dateianfang definieren
@@ -187,4 +164,4 @@ pydocstyle src/
 | AGENT-601 | README Struktur & Troubleshooting | ✅ | 2be2d20 |
 | AGENT-402 | Modell-Download-Fehler behandeln | ✅ | 53bc7a6, tests/test_errors.py |
 | AGENT-403 | OOM-Handling im SD-Refine | ✅ | 53bc7a6, tests/test_errors.py |
-| AGENT-501 | Typisierung & Black-Format | ✅ | 53bc7a6 |
+| AGENT-501 | Typisierung & Ruff-Format | ✅ | 53bc7a6 |

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+format:
+	ruff format .
+
+lint:
+	ruff check . --fix
+
+typecheck:
+	basedpyright --outputjson
+
+vulture:
+	vulture src tests
+
+refurb:
+	refurb src tests
+
+deptry:
+	deptry .
+
+full-check:
+	ruff format .
+	ruff check . --fix
+	basedpyright --outputjson
+	vulture src tests
+	refurb src tests
+	deptry .
+
+.PHONY: format lint typecheck vulture refurb deptry full-check

--- a/README.md
+++ b/README.md
@@ -14,6 +14,50 @@ pip install -r requirements.txt
 python main.py
 ```
 
+## Entwicklung
+
+Ruff ersetzt Flake8, Black, isort und Pylint; BasedPyright löst mypy ab. Vulture, Refurb und Deptry prüfen zusätzlich auf toten Code, Modernisierungspotenzial und saubere Abhängigkeiten.
+
+### Setup (Windows 11, Python ≥ 3.10)
+
+```
+py -3.10 -m venv .venv
+.\.venv\Scripts\activate
+pip install -r requirements.txt -r requirements-dev.txt
+```
+
+### Prüfbefehle
+
+```
+ruff format .
+ruff check . --fix
+basedpyright --outputjson
+vulture src tests
+refurb src tests
+deptry .
+```
+
+Alle Schritte lassen sich gebündelt ausführen:
+
+```
+make full-check
+```
+
+### Beispielausgabe
+
+```
+$ make full-check
+ruff format .
+ruff check . --fix
+basedpyright --outputjson
+vulture src tests
+  tests/test_errors.py:18: unused variable 'args' (100% confidence)
+refurb src tests
+  src/pipeline.py:142:57 [FURB111]: Replace `lambda: False` with `bool`
+deptry .
+  Success! No dependency issues found.
+```
+
 ## Features
 - DexiNed edge detection
 - SD 1.5 + ControlNet lineart refinement

--- a/main.py
+++ b/main.py
@@ -513,7 +513,7 @@ class App(BaseTk):
                 eta = (total - cur) / (spm / 60) if spm > 0 else 0
                 self.status_var.set(
                     f"{ICON_WORK} {name} – {cur}/{total} | "
-                    f"{spm:.1f} img/min | ETA {eta/60:.1f}m"
+                    f"{spm:.1f} img/min | ETA {eta / 60:.1f}m"
                 )
         _ = self.after(100, self.process_log_queue)
 
@@ -532,7 +532,7 @@ class App(BaseTk):
             try:
                 prefetch_models(self.log)
                 messagebox.showinfo("Fertig", "Alle Modelle sind lokal verfügbar.")
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 messagebox.showerror("Fehler beim Herunterladen", str(e))
 
         threading.Thread(target=job, daemon=True).start()
@@ -561,7 +561,7 @@ class App(BaseTk):
         if not out.exists():
             try:
                 out.mkdir(parents=True, exist_ok=True)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 messagebox.showerror(
                     "Fehler", f"Ausgabeordner kann nicht erstellt werden:\n{e}"
                 )
@@ -604,7 +604,7 @@ class App(BaseTk):
                 process_folder(
                     inp, out, cfg, self.log, self.done, self.stop_event, self.progress
                 )
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 self.log(f"FEHLER: {e}")
                 self.done()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,6 @@ dependencies = [
 gui = ["tkinterdnd2"]
 svg = ["vtracer"]
 
-[tool.black]
-line-length = 88
-target-version = ["py311"]
-
 [tool.ruff]
 line-length = 88
 target-version = "py311"
@@ -34,17 +30,7 @@ select = ["E","F","W","I","UP","D","B","C90"]
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.mypy]
-python_version = "3.11"
-strict = true
-ignore_missing_imports = true
-
-[tool.pylint.'MAIN']
-# Beispiel: Naming/Gewichtung etc.
-
-[tool.vulture]
-min_confidence = 80
-exclude = ["tests/*"]
-
 [tool.deptry]
-# Beispiel: Regeln/Ignores hier steuern
+
+[tool.deptry.per_rule_ignores]
+DEP002 = ["transformers", "accelerate", "xformers", "vtracer"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,3 @@
+{
+  "exclude": ["build", "dist", ".venv"]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+ruff
+basedpyright
+vulture
+deptry
+refurb

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -8,7 +8,6 @@ lightweight.
 from __future__ import annotations
 
 # pyright: reportArgumentType=false, reportAttributeAccessIssue=false
-# pylint: disable=import-error,no-name-in-module,too-many-locals,too-many-arguments,too-many-positional-arguments,import-outside-toplevel,broad-exception-caught,invalid-name,no-member,line-too-long,protected-access
 import logging
 import shutil
 import subprocess
@@ -446,9 +445,7 @@ def get_dexined(
         float(np.percentile(edge, 5)),
         float(np.percentile(edge, 99)),
     )
-    edge = exposure.rescale_intensity(
-        edge, in_range=lo_hi
-    )  # pyright: ignore[reportArgumentType]
+    edge = exposure.rescale_intensity(edge, in_range=lo_hi)  # pyright: ignore[reportArgumentType]
     if cv2 is not None:
         edge = cv2.GaussianBlur(edge, (0, 0), 0.7)
     else:
@@ -698,7 +695,7 @@ def process_one(
         with Image.open(path) as img:
             img.verify()
         src = ensure_rgb(Image.open(path))
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as exc:
         log(f"FEHLER: {path.name} – {exc}")
         return
 
@@ -731,7 +728,7 @@ def process_one(
                 seed=cfg["seed"],
                 max_long=cfg["max_long"],
             )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             log(f"FEHLER bei SD-Refinement: {exc}")
             return
         ref_path = out_dir / f"{path.stem}_refined.png"


### PR DESCRIPTION
## Summary
- remove legacy lint/type-check configs and directives
- add unified Ruff/BasedPyright/Vulture/Refurb/Deptry tooling with Makefile, pre-commit and CI
- document new development workflow and dependency setup

## Testing
- `ruff format .`
- `ruff check . --fix`
- `basedpyright --outputjson`
- `vulture src tests`
- `refurb src tests`
- `deptry .`


------
https://chatgpt.com/codex/tasks/task_e_68c06a71da208327b0b4ade5305bb394