### PR TITLE
Fix autocast handling and close image handles

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -52,7 +52,7 @@ def test_load_sd15_lineart_download_error(monkeypatch) -> None:
 
 def test_sd_refine_oom(monkeypatch) -> None:
     """sd_refine raises friendly OOM errors."""
-    monkeypatch.setattr(pipeline, "load_sd15_lineart", lambda: DummyPipe())
+    monkeypatch.setattr(pipeline, "load_sd15_lineart", DummyPipe)
     img = Image.new("RGB", (64, 64))
     with pytest.raises(RuntimeError):
         pipeline.sd_refine(img, img)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,11 @@
 # noqa: D100
 
+from contextlib import nullcontext
+
+import torch
 from PIL import Image
 
+from src import pipeline
 from src.pipeline import detect_dtype, ensure_rgb, list_images, resize_img
 
 
@@ -9,7 +13,7 @@ def test_resize_img_limits_and_multiple_of_eight() -> None:
     """Resizing keeps dimensions within limit and multiples of eight."""
     w, h = resize_img(2000, 1000, max_long=1000)
     assert max(w, h) <= 1000
-    assert w % 8 == 0 and h % 8 == 0
+    assert w % 8 == h % 8 == 0
 
 
 def test_ensure_rgb_converts_mode() -> None:
@@ -17,6 +21,13 @@ def test_ensure_rgb_converts_mode() -> None:
     img = Image.new("L", (10, 10))
     rgb = ensure_rgb(img)
     assert rgb.mode == "RGB"
+
+
+def test_ensure_rgb_returns_copy_for_rgb() -> None:
+    """ensure_rgb returns a copy so the source file handle is released."""
+    img = Image.new("RGB", (10, 10))
+    rgb = ensure_rgb(img)
+    assert rgb is not img
 
 
 def test_list_images_sorted(tmp_path) -> None:
@@ -42,5 +53,38 @@ def test_detect_dtype_cpu(monkeypatch) -> None:
     monkeypatch.setattr(
         torch.cuda, "is_bf16_supported", lambda: (_ for _ in ()).throw(RuntimeError)
     )
-    monkeypatch.setattr(torch.cpu, "_is_avx512_bf16_supported", lambda: False)
+    monkeypatch.setattr(torch.cpu, "_is_avx512_bf16_supported", bool)
     assert detect_dtype("cpu") is torch.float32
+
+
+def test_autocast_context_skips_unsupported_dtype(monkeypatch) -> None:
+    """_autocast_context should not call torch.autocast for unsupported combos."""
+    called = False
+
+    def fake_autocast(*_args, **_kwargs):  # noqa: D401
+        """Record the call and return a dummy context manager."""
+        nonlocal called
+        called = True
+        return nullcontext()
+
+    monkeypatch.setattr(torch, "autocast", fake_autocast)
+    ctx = pipeline._autocast_context(torch.device("cpu"), torch.float32)
+    assert not called
+    assert isinstance(ctx, type(nullcontext()))
+
+
+def test_autocast_context_cpu_bfloat16(monkeypatch) -> None:
+    """Supported CPU dtype should call torch.autocast."""
+    called = False
+
+    def fake_autocast(*_args, **_kwargs):  # noqa: D401
+        """Record invocation."""
+        nonlocal called
+        called = True
+        return nullcontext()
+
+    monkeypatch.setattr(torch, "autocast", fake_autocast)
+    ctx = pipeline._autocast_context(torch.device("cpu"), torch.bfloat16)
+    assert called
+    with ctx:
+        pass


### PR DESCRIPTION
## Summary
- add a dedicated autocast context helper that skips unsupported device and dtype combinations and normalise generator device strings
- ensure RGB conversion always copies the image and reopen files within context managers to release handles promptly
- extend utility tests to cover the new autocast helper and RGB copy behaviour while adjusting existing mocks

## Testing
- ruff format .
- ruff check . --fix
- basedpyright --outputjson
- vulture src tests --ignore-names 'use_sd,save_svg'
- time refurb src tests
- deptry .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef41d608083278ede5845135435e6