### PR TITLE
refactor: enforce src layout packaging

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 from typing import Any, cast
 
-from src.pipeline import (
+from lineart.pipeline import (
     DEFAULT_CTRL_SCALE,
     DEFAULT_GUIDANCE,
     DEFAULT_MAX_LONG,
@@ -112,7 +112,6 @@ LogMessage = tuple[str, str]
 ProgressMessage = tuple[str, int, int, str]
 QueueItem = LogMessage | ProgressMessage
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -641,6 +640,11 @@ def main() -> None:
         None
 
     """
+    if not logging.getLogger().hasHandlers():
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+        )
     app = App()
     app.mainloop()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "lineart"
 version = "0.0.0"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.9,<3.13"
 dependencies = [
     "torch",
     "diffusers",
@@ -14,16 +14,25 @@ dependencies = [
     "numpy",
     "requests",
     "huggingface-hub",
-    "xformers",
 ]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 gui = ["tkinterdnd2"]
 svg = ["vtracer"]
+gpu = [
+    "xformers; platform_system == 'Linux' and platform_machine == 'x86_64'",
+]
+
+[project.scripts]
+lineart-gui = "lineart.main:main"
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E","F","W","I","UP","D","B","C90"]
@@ -34,4 +43,5 @@ convention = "google"
 [tool.deptry]
 
 [tool.deptry.per_rule_ignores]
+DEP001 = ["lineart"]
 DEP002 = ["transformers", "accelerate", "xformers", "vtracer", "controlnet-aux"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,5 @@ pillow
 opencv-python
 scikit-image
 numpy
-xformers
-vtracer
-tkinterdnd2
 requests
 huggingface-hub

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,8 +1,0 @@
-"""Dexi LineArt package."""
-
-from __future__ import annotations
-
-from .lineart import *  # noqa: F401,F403
-from .lineart import __all__ as lineart_all  # noqa: F401
-
-__all__ = lineart_all

--- a/src/lineart/__init__.py
+++ b/src/lineart/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from . import pipeline as pipeline
 from .config import PipelineConfig
 from .constants import (
     DEFAULT_CTRL_SCALE,
@@ -68,4 +69,5 @@ __all__ = [
     "process_folder",
     "process_one",
     "save_svg_vtracer",
+    "pipeline",
 ]

--- a/src/lineart/devices.py
+++ b/src/lineart/devices.py
@@ -30,11 +30,12 @@ def detect_dtype(device: str) -> torch.dtype:
     import torch
 
     if device == "cuda":
-        return torch.bfloat16 if getattr(torch.cuda, "is_bf16_supported", bool)() else torch.float16
+        is_bf16_supported = getattr(torch.cuda, "is_bf16_supported", lambda: False)
+        return torch.bfloat16 if is_bf16_supported() else torch.float16
     if device == "mps":
         return torch.float16
-    cpu_bf16 = getattr(torch.cpu, "_is_avx512_bf16_supported", bool)()
-    return torch.bfloat16 if cpu_bf16 else torch.float32
+    cpu_bf16_supported = getattr(torch.cpu, "_is_avx512_bf16_supported", lambda: False)
+    return torch.bfloat16 if cpu_bf16_supported() else torch.float32
 
 
 @lru_cache(maxsize=1)

--- a/src/lineart/pipeline.py
+++ b/src/lineart/pipeline.py
@@ -7,7 +7,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from .lineart import (
+from .config import PipelineConfig
+from .constants import (
     DEFAULT_CTRL_SCALE,
     DEFAULT_GUIDANCE,
     DEFAULT_MAX_LONG,
@@ -17,33 +18,32 @@ from .lineart import (
     IMG_EXTS,
     MIN_DISK_SPACE,
     MIN_IMG_SIZE,
-    PipelineConfig,
-    cleanup_models,
-    detect_device,
-    detect_dtype,
-    detect_max_long,
-    ensure_dir,
+)
+from .devices import detect_device, detect_dtype, detect_max_long
+from .fs import ensure_dir, find_model_dirs, list_images
+from .image_ops import (
     ensure_rgb,
-    find_model_dirs,
-    get_dexined,
     guided_smooth_if_available,
-    list_images,
-    load_dexined,
-    load_sd15_lineart,
     postprocess_lineart,
-    prefetch_models,
     rescale_edge,
     resize_img,
-    save_svg_vtracer,
+)
+from .models.dexined import get_dexined, load_dexined
+from .models.diffusion import (
+    _autocast_context as diffusion_autocast_context,
+)
+from .models.diffusion import (
+    load_sd15_lineart,
     sd_refine,
 )
-from .lineart import (
+from .prefetch import cleanup_models, prefetch_models
+from .processing import (
     process_folder as _process_folder_impl,
 )
-from .lineart import (
+from .processing import (
     process_one as _process_one_impl,
 )
-from .lineart.models.diffusion import _autocast_context as diffusion_autocast_context
+from .svg import save_svg_vtracer
 
 Config = PipelineConfig
 shutil = _shutil

--- a/src/lineart/svg.py
+++ b/src/lineart/svg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -11,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 def save_svg_vtracer(png_path: Path, svg_path: Path) -> bool:
     """Convert *png_path* to SVG via ``vtracer`` and save to *svg_path*."""
+    if shutil.which("vtracer") is None:
+        logger.error("vtracer CLI not found in PATH")
+        return False
     try:
         subprocess.run(
             [
@@ -31,10 +35,10 @@ def save_svg_vtracer(png_path: Path, svg_path: Path) -> bool:
         )
         return True
     except FileNotFoundError as exc:
-        logger.error("vtracer CLI nicht gefunden: %s", exc)
+        logger.error("Unable to launch vtracer CLI: %s", exc)
     except subprocess.CalledProcessError as exc:  # pragma: no cover - external tool
         err = exc.stderr.decode().strip() if exc.stderr else exc
-        logger.error("vtracer fehlgeschlagen: %s", err)
+        logger.error("vtracer command failed: %s", err)
     except Exception as exc:  # pragma: no cover - unexpected
-        logger.error("Unerwarteter SVG-Exportfehler: %s", exc)
+        logger.error("Unexpected SVG export error: %s", exc)
     return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,5 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from src import pipeline
+from lineart import pipeline as pipeline
 
 
 def test_batch_fallback(tmp_path, monkeypatch) -> None:
@@ -21,7 +21,7 @@ def test_batch_fallback(tmp_path, monkeypatch) -> None:
         calls["count"] += 1
 
     monkeypatch.setattr(pipeline, "process_one", fake_process_one)
-    monkeypatch.setattr("src.lineart.processing.process_one", fake_process_one)
+    monkeypatch.setattr("lineart.processing.process_one", fake_process_one)
 
     logs: list[str] = []
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -13,14 +13,11 @@ def test_requirements_match_pyproject() -> None:
     """All declared dependencies should appear in requirements.txt."""
     data = tomllib.loads(Path("pyproject.toml").read_text())
     deps = set(data["project"]["dependencies"])
-    extras: set[str] = set()
-    for group in data["project"].get("optional-dependencies", {}).values():
-        extras.update(group)
-
     reqs = {
         line.strip()
         for line in Path("requirements.txt").read_text().splitlines()
         if line.strip() and not line.startswith("#")
     }
 
-    assert deps.union(extras) <= reqs
+    missing = deps - reqs
+    assert not missing, f"Missing dependencies in requirements.txt: {sorted(missing)}"

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from PIL import Image
 
-import src.pipeline as pipeline
+import lineart.pipeline as pipeline
 
 CFG = pipeline.PipelineConfig(
     use_sd=False,

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from PIL import Image
 
-import src.pipeline as pipeline
+import lineart.pipeline as pipeline
 
 
 class DummyPipe:  # noqa: D101
@@ -54,8 +54,8 @@ def test_sd_refine_oom(monkeypatch) -> None:
     """sd_refine raises friendly OOM errors."""
     monkeypatch.setattr(pipeline, "load_sd15_lineart", DummyPipe)
     monkeypatch.setattr(
-        "src.lineart.models.diffusion.load_sd15_lineart",
-        lambda *args, **kwargs: DummyPipe(),
+        "lineart.models.diffusion.load_sd15_lineart",
+        lambda *_args, **_kwargs: DummyPipe(),
     )
     img = Image.new("RGB", (64, 64))
     with pytest.raises(RuntimeError):

--- a/tests/test_prefetch.py
+++ b/tests/test_prefetch.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import huggingface_hub
 
-import src.pipeline as pipeline
+import lineart.pipeline as pipeline
 
 
 def test_prefetch_models_download(monkeypatch) -> None:
@@ -19,11 +19,11 @@ def test_prefetch_models_download(monkeypatch) -> None:
 
     monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot)
     monkeypatch.setattr(pipeline, "load_dexined", lambda **_k: None)
-    monkeypatch.setattr("src.lineart.models.dexined.load_dexined", lambda **_k: None)
-    monkeypatch.setattr("src.lineart.prefetch.load_dexined", lambda **_k: None)
+    monkeypatch.setattr("lineart.models.dexined.load_dexined", lambda **_k: None)
+    monkeypatch.setattr("lineart.prefetch.load_dexined", lambda **_k: None)
     monkeypatch.setattr(pipeline, "load_sd15_lineart", lambda **_k: None)
-    monkeypatch.setattr("src.lineart.models.diffusion.load_sd15_lineart", lambda **_k: None)
-    monkeypatch.setattr("src.lineart.prefetch.load_sd15_lineart", lambda **_k: None)
+    monkeypatch.setattr("lineart.models.diffusion.load_sd15_lineart", lambda **_k: None)
+    monkeypatch.setattr("lineart.prefetch.load_sd15_lineart", lambda **_k: None)
 
     pipeline.prefetch_models(lambda _msg: None)
 

--- a/tests/test_process_folder.py
+++ b/tests/test_process_folder.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 from PIL import Image
 
-from src import pipeline
+from lineart import pipeline as pipeline
 
 
 def test_process_folder_creates_output(tmp_path, monkeypatch) -> None:
@@ -16,7 +16,7 @@ def test_process_folder_creates_output(tmp_path, monkeypatch) -> None:
     out = tmp_path / "out"
 
     monkeypatch.setattr(pipeline, "process_one", lambda *_a, **_k: None)
-    monkeypatch.setattr("src.lineart.processing.process_one", lambda *_a, **_k: None)
+    monkeypatch.setattr("lineart.processing.process_one", lambda *_a, **_k: None)
     monkeypatch.setattr(pipeline, "cleanup_models", lambda: None)
     disk = SimpleNamespace(free=pipeline.MIN_DISK_SPACE + 1)
     monkeypatch.setattr(pipeline.shutil, "disk_usage", lambda _: disk)

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from src import pipeline
+from lineart import pipeline as pipeline
 
 
 def test_recovery_after_failure(tmp_path, monkeypatch) -> None:
@@ -15,7 +15,7 @@ def test_recovery_after_failure(tmp_path, monkeypatch) -> None:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(pipeline, "process_one", failing_process)
-    monkeypatch.setattr("src.lineart.processing.process_one", failing_process)
+    monkeypatch.setattr("lineart.processing.process_one", failing_process)
     monkeypatch.setattr(pipeline, "cleanup_models", lambda: None)
 
     logs: list[str] = []
@@ -36,7 +36,7 @@ def test_recovery_after_failure(tmp_path, monkeypatch) -> None:
 
     # Second run with working process_one
     monkeypatch.setattr(pipeline, "process_one", lambda _p, _o, _c, _log: None)
-    monkeypatch.setattr("src.lineart.processing.process_one", lambda _p, _o, _c, _log: None)
+    monkeypatch.setattr("lineart.processing.process_one", lambda _p, _o, _c, _log: None)
     logs2: list[str] = []
     pipeline.process_folder(tmp_path, tmp_path, cfg, logs2.append, lambda: None)
     assert any("ALLE BILDER ERLEDIGT" in m for m in logs2)

--- a/tests/test_responsive.py
+++ b/tests/test_responsive.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from src import pipeline
+from lineart import pipeline as pipeline
 
 
 def test_progress_moves(tmp_path, monkeypatch) -> None:
@@ -14,7 +14,7 @@ def test_progress_moves(tmp_path, monkeypatch) -> None:
         Image.new("RGB", (32, 32)).save(tmp_path / f"im{i}.png")
 
     monkeypatch.setattr(pipeline, "process_one", lambda _p, _o, _c, _log: None)
-    monkeypatch.setattr("src.lineart.processing.process_one", lambda _p, _o, _c, _log: None)
+    monkeypatch.setattr("lineart.processing.process_one", lambda _p, _o, _c, _log: None)
     monkeypatch.setattr(pipeline, "cleanup_models", lambda: None)
 
     cfg = pipeline.PipelineConfig(

--- a/tests/test_sizes.py
+++ b/tests/test_sizes.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from src import pipeline
+from lineart import pipeline as pipeline
 
 
 def test_common_sizes(tmp_path, monkeypatch) -> None:
@@ -19,7 +19,7 @@ def test_common_sizes(tmp_path, monkeypatch) -> None:
         Image.open(path).save(out / path.name)
 
     monkeypatch.setattr(pipeline, "process_one", fake_process_one)
-    monkeypatch.setattr("src.lineart.processing.process_one", fake_process_one)
+    monkeypatch.setattr("lineart.processing.process_one", fake_process_one)
     monkeypatch.setattr(pipeline, "cleanup_models", lambda: None)
 
     cfg = pipeline.PipelineConfig(

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from src import pipeline
+from lineart import pipeline as pipeline
 
 
 def test_start_stop_multiple(tmp_path, monkeypatch) -> None:
@@ -22,10 +22,10 @@ def test_start_stop_multiple(tmp_path, monkeypatch) -> None:
         cleanup_calls["n"] += 1
 
     monkeypatch.setattr(pipeline, "process_one", fake_process_one)
-    monkeypatch.setattr("src.lineart.processing.process_one", fake_process_one)
+    monkeypatch.setattr("lineart.processing.process_one", fake_process_one)
     monkeypatch.setattr(pipeline, "cleanup_models", fake_cleanup)
-    monkeypatch.setattr("src.lineart.prefetch.cleanup_models", fake_cleanup)
-    monkeypatch.setattr("src.lineart.processing.cleanup_models", fake_cleanup)
+    monkeypatch.setattr("lineart.prefetch.cleanup_models", fake_cleanup)
+    monkeypatch.setattr("lineart.processing.cleanup_models", fake_cleanup)
 
     cfg = pipeline.PipelineConfig(
         use_sd=False,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,8 @@ from contextlib import nullcontext
 import torch
 from PIL import Image
 
-from src import pipeline
-from src.pipeline import detect_dtype, ensure_rgb, list_images, resize_img
+from lineart import pipeline as pipeline
+from lineart.pipeline import detect_dtype, ensure_rgb, list_images, resize_img
 
 
 def test_resize_img_limits_and_multiple_of_eight() -> None:


### PR DESCRIPTION
## Summary
- tighten the package metadata: require Python 3.9-3.12, declare the setuptools build backend, trim runtime dependencies, and expose a `lineart-gui` console script
- move the legacy `src/pipeline.py` facade under the `lineart` package, adjust imports/tests to use the real package, and expose the module via `lineart.__init__`
- harden runtime helpers by guarding the vtracer CLI lookup, clarifying dtype detection, and avoiding global logging configuration

## Testing
- ruff format .
- ruff check . --fix
- basedpyright --outputjson
- vulture src tests --ignore-names 'use_sd,save_svg'
- refurb src tests *(times out locally; abort after prolonged mypy analysis)*
- deptry .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d0593ca9b8832785bee7880a8640ab