### PR TITLE
Align Python support and CI with extras-based setup

### DIFF
--- a/.github/workflows/lint-advisory.yml
+++ b/.github/workflows/lint-advisory.yml
@@ -9,10 +9,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      - name: Install dev tools
+      - name: Install project extras
         run: |
           python -m pip install --upgrade pip
-          pip install ruff basedpyright vulture deptry refurb
+          pip install ".[dev,test]"
       - name: Ruff format (check)
         run: ruff format --check . || true
         continue-on-error: true
@@ -21,6 +21,9 @@ jobs:
         continue-on-error: true
       - name: BasedPyright
         run: basedpyright --outputjson > pyright_report.json || true
+        continue-on-error: true
+      - name: Pytest
+        run: pytest -q --disable-warnings --maxfail=1 --junitxml=pytest-report.xml || true
         continue-on-error: true
       - name: Vulture
         run: |
@@ -39,6 +42,7 @@ jobs:
           echo "- Ruff format check: nicht-blockierend" >> $GITHUB_STEP_SUMMARY
           echo "- Ruff lint: nicht-blockierend" >> $GITHUB_STEP_SUMMARY
           echo "- BasedPyright: pyright_report.json" >> $GITHUB_STEP_SUMMARY
+          echo "- Pytest: pytest-report.xml" >> $GITHUB_STEP_SUMMARY
           echo "- Vulture: vulture_report.txt" >> $GITHUB_STEP_SUMMARY
           echo "- Refurb: refurb_report.txt" >> $GITHUB_STEP_SUMMARY
           echo "- Deptry: deptry_report.json" >> $GITHUB_STEP_SUMMARY
@@ -52,3 +56,4 @@ jobs:
             vulture_report.txt
             refurb_report.txt
             deptry_report.json
+            pytest-report.xml

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ typecheck:
 	basedpyright --outputjson
 
 vulture:
-        vulture src tests --ignore-names 'use_sd,save_svg'
+	vulture src tests --ignore-names 'use_sd,save_svg'
 
 refurb:
 	refurb src tests
@@ -17,11 +17,11 @@ deptry:
 	deptry .
 
 full-check:
-        ruff format .
-        ruff check . --fix
-        basedpyright --outputjson
-        vulture src tests --ignore-names 'use_sd,save_svg'
-        refurb src tests
-        deptry .
+	ruff format .
+	ruff check . --fix
+	basedpyright --outputjson
+	vulture src tests --ignore-names 'use_sd,save_svg'
+	refurb src tests
+	deptry .
 
 .PHONY: format lint typecheck vulture refurb deptry full-check

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Dexi LineArt Max
 
-*Benötigt Python >=3.8,<3.12*
+*Benötigt Python >=3.10,<3.13*
 
 ## Installation
 ```
 python -m venv .venv
 . .venv/bin/activate
-pip install -r requirements.txt
+pip install .[test]
 ```
 
 ## Quickstart
@@ -23,10 +23,10 @@ Ruff ersetzt Flake8, Black, isort und Pylint; BasedPyright löst mypy ab. Vultur
 ```
 py -3.10 -m venv .venv
 .\.venv\Scripts\activate
-pip install -r requirements.txt -r requirements-dev.txt
+pip install .[dev,test]
 ```
 
-`requirements-dev.txt` enthält Ruff, BasedPyright, Vulture, Refurb, Deptry sowie Pytest für die Tests.
+Die Entwicklungs-Extras installieren Ruff, BasedPyright, Vulture, Refurb und Deptry; das Test-Extra bringt Pytest sowie Tomli für Python 3.10 mit.
 
 ### Prüfbefehle
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [project]
 name = "lineart"
 version = "0.0.0"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "torch",
     "diffusers",
     "transformers",
     "accelerate",
     "controlnet-aux",
-    "pillow",
-    "opencv-python",
+    "pillow>=9.1",
+    "opencv-python-headless",
     "scikit-image",
     "numpy",
     "requests",
@@ -21,6 +21,17 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
+test = [
+    "pytest",
+    "tomli; python_version < '3.11'",
+]
+dev = [
+    "ruff",
+    "basedpyright",
+    "vulture",
+    "deptry",
+    "refurb",
+]
 gui = ["tkinterdnd2"]
 svg = ["vtracer"]
 gpu = [
@@ -32,7 +43,7 @@ lineart-gui = "lineart.main:main"
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E","F","W","I","UP","D","B","C90"]
@@ -44,4 +55,17 @@ convention = "google"
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["lineart"]
-DEP002 = ["transformers", "accelerate", "xformers", "vtracer", "controlnet-aux"]
+DEP002 = [
+    "transformers",
+    "accelerate",
+    "xformers",
+    "vtracer",
+    "controlnet-aux",
+    "pytest",
+    "tomli",
+    "ruff",
+    "basedpyright",
+    "vulture",
+    "deptry",
+    "refurb",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ diffusers
 transformers
 accelerate
 controlnet-aux
-pillow
-opencv-python
+pillow>=9.1
+opencv-python-headless
 scikit-image
 numpy
 requests


### PR DESCRIPTION
## Summary
- raise the project floor to Python 3.10, pin Pillow, switch to headless OpenCV, and add structured dev/test extras with matching deptry ignores
- document extras-based installation commands and fix Makefile recipes to use tab-indented commands
- update the lint-advisory workflow to install extras and execute pytest with a junit report artifact

## Testing
- ruff format .
- ruff check . --fix
- basedpyright --outputjson >/tmp/basedpyright.json
- vulture src tests --ignore-names 'use_sd,save_svg'
- refurb src tests
- deptry .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d180674c388327b895681a41f827df